### PR TITLE
Fix raven spawn, trap drops, and bump mod version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loom_version=1.15-SNAPSHOT
 yarn_mappings=1.20.1+build.10
 
 # Mod Properties
-mod_version=0.1.4
+mod_version=0.1.5
 maven_group=com.rnoobb.rats
 archives_base_name=rats-and-creatures
 

--- a/src/main/java/com/rnoobb/rats/block/TrapBlock.java
+++ b/src/main/java/com/rnoobb/rats/block/TrapBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
+import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.ActionResult;
@@ -123,13 +124,21 @@ public class TrapBlock extends BlockWithEntity {
 
         if (world.getBlockEntity(pos) instanceof TrapBlockEntity trapBlockEntity) {
             ItemScatterer.spawn(world, pos, trapBlockEntity.getDroppedStacks());
-            if (trapBlockEntity.hasCapturedEntity()) {
-                Block.dropStack(world, pos, CageItem.createFilledCage(new ItemStack(ModBlocks.CAGE), trapBlockEntity.removeCapturedEntity()));
-            }
-            world.removeBlockEntity(pos);
         }
 
         super.onStateReplaced(state, world, pos, newState, moved);
+    }
+
+    @Override
+    public BlockState getPlacementState(ItemPlacementContext ctx) {
+        boolean closed = false;
+        if (ctx.getStack().getNbt() != null) {
+            net.minecraft.nbt.NbtCompound blockEntityTag = ctx.getStack().getSubNbt("BlockEntityTag");
+            if (blockEntityTag != null && blockEntityTag.contains("CapturedEntity")) {
+                closed = true;
+            }
+        }
+        return this.getDefaultState().with(CLOSED, closed);
     }
 
     @Override

--- a/src/main/java/com/rnoobb/rats/entity/custom/RavenEntity.java
+++ b/src/main/java/com/rnoobb/rats/entity/custom/RavenEntity.java
@@ -53,6 +53,8 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.block.BlockState;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.LocalDifficulty;
 import net.minecraft.world.ServerWorldAccess;
@@ -267,7 +269,8 @@ public class RavenEntity extends AbstractHelperEntity implements GeoEntity {
             return true;
         }
         BlockPos ground = pos.down();
-        return world.getBlockState(ground).isSolidBlock(world, ground) && world.isSkyVisible(pos);
+        BlockState state = world.getBlockState(ground);
+        return (state.isSolidBlock(world, ground) || state.isIn(BlockTags.LEAVES) || state.isIn(BlockTags.LOGS)) && world.isSkyVisible(pos);
     }
 
     @Override

--- a/src/main/java/com/rnoobb/rats/world/ModWorldGeneration.java
+++ b/src/main/java/com/rnoobb/rats/world/ModWorldGeneration.java
@@ -20,7 +20,7 @@ public class ModWorldGeneration {
         SpawnRestriction.register(ModEntities.BAT, SpawnRestriction.Location.NO_RESTRICTIONS,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, BatCompanionEntity::canSpawn);
         SpawnRestriction.register(ModEntities.RAVEN, SpawnRestriction.Location.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, RavenEntity::canSpawn);
+                Heightmap.Type.MOTION_BLOCKING, RavenEntity::canSpawn);
         SpawnRestriction.register(ModEntities.RAT, SpawnRestriction.Location.ON_GROUND,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, RatEntity::canSpawn);
     }

--- a/src/main/resources/data/rats_and_creatures/loot_tables/blocks/trap.json
+++ b/src/main/resources/data/rats_and_creatures/loot_tables/blocks/trap.json
@@ -6,7 +6,20 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "rats_and_creatures:trap"
+          "name": "rats_and_creatures:trap",
+          "functions": [
+            {
+              "function": "minecraft:copy_nbt",
+              "source": "block_entity",
+              "ops": [
+                {
+                  "source": "CapturedEntity",
+                  "target": "BlockEntityTag.CapturedEntity",
+                  "op": "replace"
+                }
+              ]
+            }
+          ]
         }
       ],
       "conditions": [


### PR DESCRIPTION
Fix raven spawn, trap drops, and bump mod version

- Update ModWorldGeneration and RavenEntity to allow spawning on leaves and logs
- Update TrapBlock to drop trap with NBT using loot table and copy_nbt function
- Remove manual cage dropping logic from TrapBlock.onStateReplaced
- Override TrapBlock.getPlacementState to read BlockEntityTag
- Bump mod version to 0.1.5

---
*PR created automatically by Jules for task [6801988556621466495](https://jules.google.com/task/6801988556621466495) started by @Rnbonnie*